### PR TITLE
Anibel - Reverse Sentence - Edges

### DIFF
--- a/lib/reverse_sentence.rb
+++ b/lib/reverse_sentence.rb
@@ -1,71 +1,48 @@
 # A method to reverse the words in a sentence, in place.
 def reverse_sentence(my_sentence)
 
-  unless my_sentence.nil?
-    back_start = my_sentence.length - 1
-    back_end = back_start
+  reverse_words(my_sentence)
 
-    temp = []
-
-    while back_start >= 0
-      if back_start == 0 || my_sentence[back_start - 1] == ' '
-        (back_start..back_end).each do |index|
-          temp << my_sentence[index]
-        end
-        back_end = back_start - 1
-
-        while my_sentence[back_end] == ' ' && back_end >= 0
-          back_end -= 1
-          temp << ' '
-        end
-
-        back_start = back_end + 1
-
-      end
-      back_start -= 1
-    end
-
-    temp.each_with_index do |letter, index|
-      my_sentence[index] = letter
-    end
-  end
+  string_reverse(my_sentence)
 
 end
 
+# A method to reverse each word in a sentence, in place.
+def reverse_words(my_words)
+  word_index_start = 0
+  word_index_end = 0
+  while my_words != nil && word_index_end <= my_words.length
+    if my_words[word_index_end] == ' ' || word_index_end == my_words.length
+      front_index = word_index_start
+      back_index = word_index_end - 1
 
+      while front_index < back_index
+        temp = my_words[front_index]
+        my_words[front_index] = my_words[back_index]
+        my_words[back_index] = temp
+        front_index += 1
+        back_index -= 1
+      end
+      word_index_start = word_index_end + 1
+    end
 
+    word_index_end += 1
+  end
+end
 
+# A method to reverse a string in place.
+def string_reverse(my_string)
+  unless my_string == nil || my_string.empty? || my_string.length == 1
 
-  # spaces = 0
-  #
-  # while last_index != my_sentence.length
-  #   if my_sentence[last_index] == ' '
-  #     space_index = last_index
-  #     # start_index = last_index + 1
-  #     while space_index > 0
-  #       my_sentence[space_index] = my_sentence[space_index - 1]
-  #       space_index -= 1
-  #     end
-  #   end
-  #
-  #   if my_sentence[last_index] != ' ' && my_sentence[last_index-1] == ' '
-  #     start_index = last_index
-  #     while my_sentence[last_index] != nil || my_sentence[last_index] != ' '
-  #       last_index += 1
-  #     end
-  #
-  #     (last_index - start_index).times do
-  #       temp = my_sentence[last_index - 1]
-  #       move_times = last_index - 1
-  #       # last_index.times do |move|
-  #       while move_times > 0
-  #         my_sentence[move_times] = my_sentence[move_times - 1]
-  #         move_times -= 1
-  #       end
-  #     end
-  #   end
-  #
-  #
-  #   last_index += 1
+    index = 0
+    last = my_string.length - 1
 
-    # raise NotImplementedError
+    while index <= last
+      temp = my_string[index]
+      my_string[index] = my_string[last]
+      my_string[last] = temp
+      index += 1
+      last -= 1
+    end
+  end
+end

--- a/lib/reverse_sentence.rb
+++ b/lib/reverse_sentence.rb
@@ -1,4 +1,71 @@
 # A method to reverse the words in a sentence, in place.
 def reverse_sentence(my_sentence)
-  raise NotImplementedError
+
+  unless my_sentence.nil?
+    back_start = my_sentence.length - 1
+    back_end = back_start
+
+    temp = []
+
+    while back_start >= 0
+      if back_start == 0 || my_sentence[back_start - 1] == ' '
+        (back_start..back_end).each do |index|
+          temp << my_sentence[index]
+        end
+        back_end = back_start - 1
+
+        while my_sentence[back_end] == ' ' && back_end >= 0
+          back_end -= 1
+          temp << ' '
+        end
+
+        back_start = back_end + 1
+
+      end
+      back_start -= 1
+    end
+
+    temp.each_with_index do |letter, index|
+      my_sentence[index] = letter
+    end
+  end
+
 end
+
+
+
+
+
+  # spaces = 0
+  #
+  # while last_index != my_sentence.length
+  #   if my_sentence[last_index] == ' '
+  #     space_index = last_index
+  #     # start_index = last_index + 1
+  #     while space_index > 0
+  #       my_sentence[space_index] = my_sentence[space_index - 1]
+  #       space_index -= 1
+  #     end
+  #   end
+  #
+  #   if my_sentence[last_index] != ' ' && my_sentence[last_index-1] == ' '
+  #     start_index = last_index
+  #     while my_sentence[last_index] != nil || my_sentence[last_index] != ' '
+  #       last_index += 1
+  #     end
+  #
+  #     (last_index - start_index).times do
+  #       temp = my_sentence[last_index - 1]
+  #       move_times = last_index - 1
+  #       # last_index.times do |move|
+  #       while move_times > 0
+  #         my_sentence[move_times] = my_sentence[move_times - 1]
+  #         move_times -= 1
+  #       end
+  #     end
+  #   end
+  #
+  #
+  #   last_index += 1
+
+    # raise NotImplementedError


### PR DESCRIPTION
The time complexity for this `reverse_sentence` implementation is linear or `O(n)`, where `n` equals the length of the array. The time complexity is linear since it it using a combination of 2 methods in succession, both of which run in `O(n)` time. The first method, reverses the words in the sentence (time complexity of `O(n)`, space complexity of `O(1)`) and the second method reverses the entire string (time complexity of `O(n)`, space complexity of `O(1)`). Since both methods are used in succession, the time complexity is `O(2*n)` but since we drop constants, it is  `O(n)`.

The space complexity of the method is constant of `O(1)` for similar reasons as above. The helper methods both allocate space to hold 3 integers each, regardless of input size. Thus, the `reverse_sentence` method has a constant space complexity as it uses up space in the cache for 6 integers regardless of input size.